### PR TITLE
add link to token economics

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -66,6 +66,21 @@
             >
               Documentation
             </a>
+            <a
+              href="https://docs.astar.network/learn/token-economics/token-allocation"
+              target="_blank"
+              class="
+                no-underline
+                block
+                mt-4
+                sm:inline-block sm:mt-0
+                text-teal-lighter
+                hover:underline hover:text-primary
+                mr-4
+              "
+            >
+              Token Economics
+            </a>
             <div
               class="
                 no-underline


### PR DESCRIPTION
add link to the token economics section on the docs
![Screen Shot 2021-11-12 at 11 47 08 AM](https://user-images.githubusercontent.com/40356749/141454858-f29c45eb-c041-4edd-9f2a-7e04164dc98a.png)

